### PR TITLE
Add chunk batching

### DIFF
--- a/scripts/test_timing.py
+++ b/scripts/test_timing.py
@@ -1,0 +1,37 @@
+from time import time
+import torch
+from punctfix import PunctFixer
+
+MODEL_INPUT = "det der sker over de tre dage fra præsident huden tav ankommer til københavn det er at der " \
+                "sådan en bliver spillet sådan et form for tom og jerry kispus mellem københavns politi og " \
+                "så de har danske demonstranter for tibet og fåfalungongsom meget gerne vil vise deres " \
+                "utilfredshed med det kinesiske regime og det de opfatter som undertrykkelse af de her " \
+                "mindretal i kine og lige nu står støttekomiteen for ti bedet bag en demonstration på" \
+                " højbro plads i københavn lisbeth davidsen hvor mange er der kommet det er ikke " \
+                "de store folkemasser der er mødt op her på" * 10
+
+def time_fp(device_str: str, batch_size: int):
+    print(">>> Profiling device %s on batch size %i" % (device_str, batch_size))
+    start = time()
+    model = PunctFixer(language="da", device=device_str, batch_size=batch_size)
+    print("Initialization time %f" % (time() - start))
+
+    # Warmup potential CUDA device
+    model.punctuate(MODEL_INPUT)
+
+    times = []
+    for _ in range(5):
+        start = time()
+        model.punctuate(MODEL_INPUT)
+        times.append(time() - start)
+    print("Average time: %f\nStd. time: %f" % (torch.tensor(times).mean().item(), torch.tensor(times).std().item()))
+
+
+if __name__ == "__main__":
+    devices = ["cpu"]
+    batch_sizes = [1, 16, 32, 64]
+    if torch.cuda.is_available():
+        devices.append("cuda")
+    for device in devices:
+        for batch_size in batch_sizes:
+            time_fp(device, batch_size)

--- a/tests/test_punctuation.py
+++ b/tests/test_punctuation.py
@@ -184,6 +184,7 @@ class GenerelFunctionalityTest(unittest.TestCase):
                                                                         device=-1,
                                                                         ignore_labels=ANY)
 
+
     def tearDown(self) -> None:
         super().tearDown()
         self.torch_cuda_patch.stop()
@@ -233,6 +234,18 @@ class NormalizationTest(unittest.TestCase):
         expected_output = model_input.split(" ")
         actual_output = self.model._split_input_text(model_input)
         self.assertEqual(actual_output, expected_output)
+
+class InputParameterTest(unittest.TestCase):
+    def test_setting_batch_size(self):
+        model_input = "mit navn det er rasmus og jeg kommer fra firmaet alvenir " \
+                      "det er mig som har trænet denne lækre model"
+        expected_output = "Mit navn det er Rasmus og jeg kommer fra firmaet Alvenir. " \
+                          "Det er mig som har trænet denne lækre model."
+        for batch_size in 1, 27, 99:
+            model = PunctFixer(language="da", batch_size=batch_size)
+            actual_output = model.punctuate(model_input)
+            self.assertEqual(actual_output, expected_output)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Result of running the timing example shown below.
On GPU, batching gives 2x speedup. On CPU 1.6x.  Batched GPU is >5x speedup compared to batched CPU.
Slightly underwhelming numbers but is probably considerably better on GPU for longer texts, haven't tested thoroughly. 

```
➜ CUDA_VISIBLE_DEVICES=0 python scripts/test_timing.py
>>> Profiling device cpu on batch size 1
Initialization time 1.187613
Average time: 1.316037
Std. time: 0.044134
>>> Profiling device cpu on batch size 16
Initialization time 1.461619
Average time: 0.809319
Std. time: 0.026769
>>> Profiling device cpu on batch size 32
Initialization time 1.456767
Average time: 0.791711
Std. time: 0.010899
>>> Profiling device cpu on batch size 64
Initialization time 1.402210
Average time: 0.807623
Std. time: 0.012546
>>> Profiling device cuda on batch size 1
Initialization time 2.387370
Average time: 0.310700
Std. time: 0.000787
>>> Profiling device cuda on batch size 16
Initialization time 1.499094
Average time: 0.150101
Std. time: 0.000458
>>> Profiling device cuda on batch size 32
Initialization time 1.382926
Average time: 0.151230
Std. time: 0.001125
>>> Profiling device cuda on batch size 64
Initialization time 1.308398
Average time: 0.151791
Std. time: 0.015773
```